### PR TITLE
Remove version pinning of 'libxml2'

### DIFF
--- a/5.1.3/Dockerfile
+++ b/5.1.3/Dockerfile
@@ -3,8 +3,8 @@ FROM httpd:2.2
 ENV PHP_VERSION 5.1.3
 
 RUN echo "deb http://httpredir.debian.org/debian wheezy main" > /etc/apt/sources.list.d/wheezy.list
-RUN apt-get update && apt-get install -t wheezy -y libxml2=2.8.0+dfsg1-7+wheezy4 \
-  libxml2-dev=2.8.0+dfsg1-7+wheezy4 \
+RUN apt-get update && apt-get install -t wheezy -y libxml2 \
+  libxml2-dev \
   libxpm4 \
   libxpm-dev \
   libxslt1.1 \


### PR DESCRIPTION
Packages could not be fetched because they were updated and removed from the Debian repos. Removing the version pinning seemed to be the best choice for not breaking it again in the future.
